### PR TITLE
Re-export serde::standard.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,9 @@ use std::{
 pub mod serde;
 
 #[cfg(feature = "serde")]
+pub use serde::standard::*;
+
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde_derive;
 


### PR DESCRIPTION
There is a breaking change in 0.5 that's not really necessary.
aws_lambda_events will pick ^ versions and will fail to compile without this export.

This leaves things back as they were to versions of aws_lambda_events before 0.6.3.

Signed-off-by: David Calavera <david.calavera@gmail.com>