### PR TITLE
Support API Gateway queryStringParameters serialization

### DIFF
--- a/src/serde/aws_api_gateway_v1.rs
+++ b/src/serde/aws_api_gateway_v1.rs
@@ -1,0 +1,58 @@
+use serde_crate::{ser::SerializeMap, Serializer};
+
+use crate::QueryMap;
+use std::collections::HashMap;
+
+/// Serializes `QueryMap`, converting value from `Vec<String>` to `String`
+pub fn serialize_query_string_parameters<S>(
+    value: &QueryMap,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let query_string_parameters: HashMap<String, String> = (*value)
+        .iter()
+        .map(|(k, _)| (String::from(k), String::from((*value).first(k).unwrap())))
+        .collect::<HashMap<String, String>>();
+
+    let mut map = serializer.serialize_map(Some(query_string_parameters.len()))?;
+    for (k, v) in &query_string_parameters {
+        map.serialize_entry(k, v)?;
+    }
+    map.end()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde::aws_api_gateway_v2::deserialize_empty;
+
+    #[test]
+    fn test_serialize_query_string_parameters() {
+        #[cfg_attr(
+            feature = "serde",
+            derive(Deserialize, Serialize),
+            serde(crate = "serde_crate")
+        )]
+        struct Test {
+            #[serde(default, deserialize_with = "deserialize_empty")]
+            #[serde(serialize_with = "serialize_query_string_parameters")]
+            pub v: QueryMap,
+        }
+
+        let data = serde_json::json!({
+            "v": {
+                "key1": ["value1", "value2", "value3"]
+            }
+        });
+
+        let decoded: Test = serde_json::from_value(data).unwrap();
+        let key1_value = decoded.v.all("key1").unwrap();
+        assert_eq!(3, key1_value.len());
+        assert_eq!("value1", *(key1_value.first().unwrap()));
+
+        let encoded = serde_json::to_string(&decoded).unwrap();
+        assert_eq!(encoded, r#"{"v":{"key1":"value1"}}"#.to_string());
+    }
+}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -3,6 +3,10 @@
 //! You need to enable the feature `serde` to access these deserializers.
 //!
 
+/// The aws_api_gateway_v1 module implements a deserializer that works with
+/// the expected format in the AWS Api Gateway V1 payloads.
+pub mod aws_api_gateway_v1;
+
 /// The aws_api_gateway_v2 module implements a deserializer that works with
 /// the expected format in the AWS Api Gateway V2 payloads.
 /// See https://github.com/calavera/query-map-rs/issues/1#issuecomment-1114463009 for more detail.


### PR DESCRIPTION
Support API Gateway queryStringParameters serialization for payload formats 1.0 and 2.0

Reference: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html `queryStringParameters` were serialized incorrectly to format like `#queryStringParameters":{"key":["value"]}` when it should be like `"queryStringParameters":{"key":"value"}`

This is related to PR https://github.com/awslabs/aws-lambda-rust-runtime/pull/676