### PR TITLE
Doc comments: Added item links & Fixed spelling mistakes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,15 @@
 
 //!
 //!
-//! `QueryMap` is a generic wrapper around `HashMap<String, Vec<String>>`
+//! [`QueryMap`] is a generic wrapper around [`HashMap<String, Vec<String>>`]
 //! to handle different transformations like URL query strings.
 //!
-//! `QueryMap` can normalize `HashMap` structures with single value elements
+//! [`QueryMap`] can normalize [`HashMap`] structures with single value elements
 //! into structures with value vector elements.
 //!
 //! # Examples
 //!
-//! Create a `QueryMap` from a `HashMap`:
+//! Create a [`QueryMap`] from a [`HashMap`]:
 //!
 //! ```
 //! use std::collections::HashMap;
@@ -26,7 +26,7 @@
 //! assert_eq!(None, map.first("bar"));
 //! ```
 //!
-//! Create a `QueryMap` from a Serde Value (requires `serde` feature):
+//! Create a [`QueryMap`] from a Serde Value (requires `serde` feature):
 //!
 //! ```ignore
 //! use query_map::QueryMap;
@@ -47,7 +47,7 @@
 //! assert_eq!("bar", test.data.first("foo").unwrap());
 //! ```
 //!
-//! Create a `QueryMap` from a query string (requires `url-query` feature):
+//! Create a [`QueryMap`] from a query string (requires `url-query` feature):
 //!
 //! ```
 //! use query_map::QueryMap;
@@ -88,7 +88,7 @@ pub use url_query::*;
 pub struct QueryMap(pub(crate) Arc<HashMap<String, Vec<String>>>);
 
 impl QueryMap {
-    /// Return the first elelemnt associated with a key
+    /// Return the first element associated with a key
     #[must_use]
     pub fn first(&self, key: &str) -> Option<&str> {
         self.0
@@ -143,7 +143,7 @@ impl From<HashMap<String, String>> for QueryMap {
     }
 }
 
-/// A read only reference to the `QueryMap`'s data
+/// A read only reference to the [`QueryMap`]'s data
 pub struct QueryMapIter<'a> {
     data: &'a QueryMap,
     keys: Keys<'a, String, Vec<String>>,

--- a/src/serde/aws_api_gateway_v1.rs
+++ b/src/serde/aws_api_gateway_v1.rs
@@ -3,7 +3,7 @@ use serde_crate::{ser::SerializeMap, Serializer};
 use crate::QueryMap;
 use std::collections::HashMap;
 
-/// Serializes `QueryMap`, converting value from `Vec<String>` to `String`
+/// Serializes [`QueryMap`], converting value from [`Vec<String>`] to [`String`]
 pub fn serialize_query_string_parameters<S>(
     value: &QueryMap,
     serializer: S,

--- a/src/serde/aws_api_gateway_v2.rs
+++ b/src/serde/aws_api_gateway_v2.rs
@@ -67,8 +67,8 @@ impl<'de> Visitor<'de> for QueryMapVisitor {
     }
 }
 
-/// Deserialize values into a `QueryMap`.
-/// This function asumes that all values have been initialized.
+/// Deserialize values into a [`QueryMap`].
+/// This function assumes that all values have been initialized.
 pub fn deserialize<'de, D>(deserializer: D) -> Result<QueryMap, D::Error>
 where
     D: Deserializer<'de>,
@@ -84,7 +84,7 @@ where
     Option::deserialize(deserializer)
 }
 
-/// Deserialize `null` values into default `QueryMap` objects
+/// Deserialize `null` values into default [`QueryMap`] objects
 pub fn deserialize_empty<'de, D>(deserializer: D) -> Result<QueryMap, D::Error>
 where
     D: Deserializer<'de>,
@@ -92,7 +92,7 @@ where
     deserializer.deserialize_option(QueryMapVisitor)
 }
 
-/// Serializes `QueryMap`, converting value from `Vec<String>` to `String`
+/// Serializes [`QueryMap`], converting value from [`Vec<String>`] to [`String`]
 pub fn serialize_query_string_parameters<S>(
     value: &QueryMap,
     serializer: S,

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,5 +1,5 @@
 //!
-//! The serde module implements derializers for payloads into QueryMap.
+//! The serde module implements deserializers for payloads into QueryMap.
 //! You need to enable the feature `serde` to access these deserializers.
 //!
 

--- a/src/serde/standard.rs
+++ b/src/serde/standard.rs
@@ -82,7 +82,7 @@ where
     Option::deserialize(deserializer)
 }
 
-/// Deserialize `null` values into default `QueryMap` objects
+/// Deserialize `null` values into default [`QueryMap`] objects
 pub fn deserialize_empty<'de, D>(deserializer: D) -> Result<QueryMap, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/url_query.rs
+++ b/src/url_query.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 impl QueryMap {
-    /// Convert a `QueryMap` into a URL query string
+    /// Convert a [`QueryMap`] into a URL query string
     pub fn to_query_string(&self) -> String {
         form_urlencoded::Serializer::new(String::new())
             .extend_pairs(self.iter())


### PR DESCRIPTION
Ran across some spelling mistakes while reading the docs and decided to create this PR. 

While at it, added links to items:
https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html

-- With love

Issue #13


